### PR TITLE
Add an example where inplace is used with xargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This is similar to the GNU sponge(1) command, which is used like this:
 The sponge usage is also supported:
 
     $ sed -e 's/foo/bar/g' | inplace somefile
+    
+inplace can also be used with xargs. The example here is looking for json files with a field called foo, and setting that field to an empty list.
+
+    $ find -name '*.json' | xargs grep '"foo":' | xargs -i@ -- inplace @ jq 'foo|=[]'
 
 The file edited in-place will be renamed into place unless the `-w` option is
 used, then the file will be re-written and will keep its identity.


### PR DESCRIPTION
So I came across this looking for inplace editing with jq. My desired use case was to find all json files with a certain field, and set that field to '[]' if it existed.

I thought it'd serve as useful documentation to add an example of using inplace with xargs, although this example is probably a bit convoluted, so please tidy it up if you thing you've got a better version.
